### PR TITLE
Deprecate the old platform info message.

### DIFF
--- a/concert_tutorials/chatter_concert/yaml/implementation.yaml
+++ b/concert_tutorials/chatter_concert/yaml/implementation.yaml
@@ -5,11 +5,11 @@
 name: "Chatter Concert"
 nodes:
   - id: dudes
-    tuple: linux.ros.pc.rocon_apps/listener
+    tuple: linux.*.ros.pc.rocon_apps/listener
     min: 0
     max: 5
   - id: dudette
-    tuple: linux.ros.pc.rocon_apps/talker
+    tuple: linux.*.ros.pc.rocon_apps/talker
     force_name_matching: true
 topics:
   - id: chatter

--- a/concert_tutorials/turtle_concert/apps/turtle_stroll/turtle_stroll.rapp
+++ b/concert_tutorials/turtle_concert/apps/turtle_stroll/turtle_stroll.rapp
@@ -1,6 +1,6 @@
 display: Turtle Stroll
 description: The turtle strolls around the tank, drawing out a square.
-platform: linux.ros.pc
+platform: linux.*.ros.pc
 launch: turtle_concert/turtle_stroll.launch
 interface: turtle_concert/turtle_stroll.interface
 icon: turtle_concert/turtle_stroll.png

--- a/concert_tutorials/turtle_concert/apps/turtle_stroll_sim/turtle_stroll_sim.rapp
+++ b/concert_tutorials/turtle_concert/apps/turtle_stroll_sim/turtle_stroll_sim.rapp
@@ -1,6 +1,6 @@
 display: Turtle Stroll
 description: The turtle strolls around the tank, drawing out a square.
-platform: linux.ros.pc
+platform: linux.*.ros.pc
 launch: turtle_concert/turtle_stroll_sim.launch
 interface: turtle_concert/turtle_stroll_sim.interface
 icon: turtle_concert/turtle_stroll_sim.png

--- a/concert_tutorials/turtle_concert/yaml/implementation.yaml
+++ b/concert_tutorials/turtle_concert/yaml/implementation.yaml
@@ -5,13 +5,13 @@
 name: "Turtle Concert"
 nodes:
   - id: kobuki
-    tuple: linux.ros.pc.turtle_concert/turtle_stroll
+    tuple: linux.*.ros.pc.turtle_concert/turtle_stroll
     force_name_matching: true
   - id: guimul
-    tuple: linux.ros.pc.turtle_concert/turtle_stroll
+    tuple: linux.*.ros.pc.turtle_concert/turtle_stroll
     force_name_matching: true
   - id: turtlesim
-    tuple: linux.ros.pc.turtle_concert/turtle_stroll_sim
+    tuple: linux.*.ros.pc.turtle_concert/turtle_stroll_sim
     force_name_matching: true
 topics:
   - id: kobuki_cmd_vel


### PR DESCRIPTION
Part of https://github.com/robotics-in-concert/rocon_app_platform/issues/88
